### PR TITLE
client: avoid infinite paging

### DIFF
--- a/src/clostack/client.clj
+++ b/src/clostack/client.clj
@@ -88,4 +88,5 @@
              width    (or width (:count desc))
              elems    (->> desc (map val) (filter vector?) first)
              pending  (- width (count elems))]
-         (lazy-cat elems (paging-request client op args (inc page) pending)))))))
+         (when (not (empty? elems))
+           (lazy-cat elems (paging-request client op args (inc page) pending))))))))


### PR DESCRIPTION
When we get no more results, stop paging. This can happen while elements
are still pending because a VM has been destroyed between two requests.
