### PR TITLE
client: send the whole response

### DIFF
--- a/src/clostack/client.clj
+++ b/src/clostack/client.clj
@@ -14,8 +14,8 @@
   ([{:keys [config pool]}]
    {:config (or config (config/init))
     :opts (if (some? pool)
-              {:pool pool}
-              {})}))
+            {:pool pool}
+            {})}))
 
 (defn wrap-body
   "Ensure that response is JSON-formatted, if so parse it"
@@ -94,4 +94,5 @@
       0 (do (Thread/sleep 1000)
             (polling-request client jobid))
       1 jobresult
-      (throw (ex-info "job failed" {:result result})))))
+      (throw (ex-info (str "job " jobid " failed")
+                      {:jobresult jobresult})))))


### PR DESCRIPTION
We will get a bit more information in the sentry logs.