### PR TITLE
client: allows to pass options to the client

### DIFF
--- a/src/clostack/client.clj
+++ b/src/clostack/client.clj
@@ -10,12 +10,10 @@
 (defn http-client
   "Create an HTTP client"
   ([]
-   http-client {})
-  ([{:keys [config pool]}]
+   (http-client {}))
+  ([{:keys [config opts] :or {opts {}}}]
    {:config (or config (config/init))
-    :opts (if (some? pool)
-            {:pool pool}
-            {})}))
+    :opts opts}))
 
 (defn wrap-body
   "Ensure that response is JSON-formatted, if so parse it"


### PR DESCRIPTION
the `:opts` key can be used to pass custom options to the client (for
example `{:throw-exceptions false}`.