### PR TITLE
date: externalize the expiration code

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject exoscale/clostack "0.2.12"
+(defproject exoscale/clostack "0.2.13-SNAPSHOT"
   :description "clojure cloudstack client"
   :url "https://github.com/exoscale/clostack"
   :license {:name "MIT License"}
@@ -7,4 +7,5 @@
   :global-vars {*warn-on-reflection* true}
   :dependencies [[org.clojure/clojure    "1.9.0"]
                  [cheshire               "5.8.1"]
+                 [clj-time               "0.14.4"]
                  [aleph                  "0.4.6"]])

--- a/src/clostack/config.clj
+++ b/src/clostack/config.clj
@@ -32,8 +32,8 @@
 (defn environment-config
   "Try getting configuration from the environment."
   []
-  (let [names [:clostack.api.key :clostack.api.secret :clostack.endpoint]
-        keys  [:api-key :api-secret :endpoint]
+  (let [names [:clostack.api.key :clostack.api.secret :clostack.endpoint :clostack.expiration]
+        keys  [:api-key :api-secret :endpoint :expiration]
         vars  (mapv getenv names)]
     (when-not (some nil? vars)
       (reduce merge {} (partition 2 (interleave keys vars))))))

--- a/src/clostack/date.clj
+++ b/src/clostack/date.clj
@@ -14,7 +14,6 @@
   ([expiration now]
    (if (>= expiration 0)
      {:signatureVersion "3"
-         ;; XXX one day, cloudstack will be able to handle more formats
       :expires          (unparse cloudstack-expires-formatter
                                  (plus now (seconds expiration)))}
      {})))
@@ -44,7 +43,6 @@
   ([expires]
    (is-expired? expires (now)))
   ([expires now]
-    ;; it accepts non timezones values (which cloudstack probably doesn't)
    (first (for [fmt formats
                 :let [date (safe-parse fmt expires)]
                 :when (and date (after? now date))]

--- a/src/clostack/date.clj
+++ b/src/clostack/date.clj
@@ -1,8 +1,8 @@
 (ns clostack.date
   "Date manipulation functions."
-  (:require [clj-time.format :refer [parse unparse formatters]]
-            [clj-time.core :refer [seconds plus now after?]])
-  (:import java.util.Date))
+  (:require [clj-time.format :refer [parse unparse-local formatters]]
+            [clj-time.coerce :refer [to-local-date-time]]
+            [clj-time.core   :refer [seconds plus now after?]]))
 
 (defn expires-args
   "Builds the expires argument map. Expiration is in seconds.
@@ -13,8 +13,12 @@
   ([expiration now]
     (if (>= expiration 0)
         {:signatureVersion "3"
-         :expires          (unparse (:date-time formatters)
-                                    (plus now (seconds expiration)))}
+         ;; XXX one day, cloudstack will be able to handle more formats
+         :expires          (str (unparse-local (:date-time-no-ms formatters)
+                                               (-> now
+                                                   (plus (seconds expiration))
+                                                   to-local-date-time))
+                                "+0000")}
         {})))
 
 (defn safe-parse
@@ -36,7 +40,7 @@
   timezone is omitted, then UTC is assumed."
   ([expires]
    (is-expired? expires (now)))
-  ([expires ^Date now]
+  ([expires now]
     ;; it accepts non timezones values (which cloudstack probably doesn't)
    (let [formats [:date-hour-minute-second
                   :date-hour-minute-second-ms

--- a/src/clostack/date.clj
+++ b/src/clostack/date.clj
@@ -33,6 +33,11 @@
       (parse fmt s)
       (catch IllegalArgumentException _))))
 
+(def formats [:date-hour-minute-second
+              :date-hour-minute-second-ms
+              :date-time
+              :date-time-no-ms])
+
 (defn is-expired?
   "If now is after the expiration, then it's expired.
 
@@ -42,14 +47,7 @@
    (is-expired? expires (now)))
   ([expires now]
     ;; it accepts non timezones values (which cloudstack probably doesn't)
-   (let [formats [:date-hour-minute-second
-                  :date-hour-minute-second-ms
-                  :date-time
-                  :date-time-no-ms]
-         dt      (first (for [fmt formats
-                              :let [date (safe-parse fmt expires)]
-                              :when date]
-                          date))]
-     (if dt
-       (after? now dt)
-       false))))
+    (first (for [fmt formats
+                 :let [date (safe-parse fmt expires)]
+                 :when (and date (after? now date))]
+                true))))

--- a/src/clostack/date.clj
+++ b/src/clostack/date.clj
@@ -1,0 +1,51 @@
+(ns clostack.date
+  "Date manipulation functions."
+  (:require [clj-time.format :refer [parse unparse formatters]]
+            [clj-time.core :refer [seconds plus now after?]])
+  (:import java.util.Date))
+
+(defn expires-args
+  "Builds the expires argument map. Expiration is in seconds.
+
+   A negative expiration meants no expires"
+  ([expiration]
+   (expires-args expiration (now)))
+  ([expiration now]
+    (if (>= expiration 0)
+        {:signatureVersion "3"
+         :expires          (unparse (:date-time formatters)
+                                    (plus now (seconds expiration)))}
+        {})))
+
+(defn safe-parse
+  "Parse a date time string with the given formatter.
+
+  See clj-time.format/parse"
+  [formatter s]
+  (let [fmt (if (keyword? formatter)
+              (formatter formatters)
+              formatter)]
+    (try
+      (parse fmt s)
+      (catch IllegalArgumentException _))))
+
+(defn is-expired?
+  "If now is after the expiration, then it's expired.
+
+  expiration must be a valid ISO 8061 date and time in UTC format, if the
+  timezone is omitted, then UTC is assumed."
+  ([expires]
+   (is-expired? expires (now)))
+  ([expires ^Date now]
+    ;; it accepts non timezones values (which cloudstack probably doesn't)
+   (let [formats [:date-hour-minute-second
+                  :date-hour-minute-second-ms
+                  :date-time
+                  :date-time-no-ms]
+         dt      (first (for [fmt formats
+                              :let [date (safe-parse fmt expires)]
+                              :when date]
+                          date))]
+     (if dt
+       (after? now dt)
+       false))))

--- a/src/clostack/payload.clj
+++ b/src/clostack/payload.clj
@@ -79,6 +79,5 @@
           args       (-> args
                          (assoc :apikey api-key :response "json")
                          (merge exp-args))
-          _          (println args)
           signature  (sign args api-secret)]
       (assoc args :signature signature))))

--- a/src/clostack/payload.clj
+++ b/src/clostack/payload.clj
@@ -1,8 +1,13 @@
 (ns clostack.payload
   "Functions to work with appropriate cloudstack payloads."
-  (:require [clojure.string     :as s]
+  (:require [clj-time.format    :as f]
+            [clj-time.core      :as t]
+            [clojure.string     :as s]
+            [clostack.date      :refer [expires-args]]
             [clostack.signature :as sig]
             [clostack.utils     :refer [url-encode quote-plus]]))
+
+(def default-expiration 600)
 
 (defn serialize-pair
   "Encode a key/value pair"
@@ -67,8 +72,13 @@
   "Build a signed payload for a given config, opcode and args triplet"
   ([config opcode args]
     (build-payload config (assoc args :command opcode)))
-  ([config args]
-    (let [{:keys    [api-key api-secret]} config
-          args      (assoc args :apikey api-key :response "json")
-          signature (sign args api-secret)]
+  ([{:keys [api-key api-secret expiration]} args]
+    (let [exp-s      (try (int expiration)
+                          (catch Exception _ default-expiration))
+          exp-args   (expires-args exp-s)
+          args       (-> args
+                         (assoc :apikey api-key :response "json")
+                         (merge exp-args))
+          _          (println args)
+          signature  (sign args api-secret)]
       (assoc args :signature signature))))

--- a/test/clostack/date_test.clj
+++ b/test/clostack/date_test.clj
@@ -1,0 +1,24 @@
+(ns clostack.date-test
+  (:require [clostack.date :refer [is-expired?]]
+            [clj-time.core :refer [date-time]]
+            [clojure.test :refer :all]))
+
+(deftest is-expired
+  (testing "no timezone"
+    (is (is-expired? "2018-01-01T12:12:12" (date-time 2018 1 1 12 12 13)))
+    (is (not (is-expired? "2018-01-02T12:12:12" (date-time 2018 1 2 12 12 11)))))
+  (testing "no timezone with milliseconds"
+    (is (is-expired? "2018-01-03T12:12:12.000" (date-time 2018 1 3 12 12 13)))
+    (is (not (is-expired? "2018-01-04T12:12:12.000" (date-time 2018 1 4 12 12 11)))))
+  (testing "utc timezone"
+    (is (is-expired? "2018-01-05T12:12:12Z" (date-time 2018 1 5 12 12 13)))
+    (is (not (is-expired? "2018-01-06T12:12:12Z" (date-time 2018 1 6 12 12 11)))))
+  (testing "utc timezone and milliseconds"
+    (is (is-expired? "2018-01-07T12:12:12.000Z" (date-time 2018 1 7 12 12 13)))
+    (is (not (is-expired? "2018-01-08T12:12:12.000Z" (date-time 2018 1 8 12 12 11)))))
+  (testing "other timezone"
+    (is (is-expired? "2018-01-09T12:12:12+02:00" (date-time 2018 1 9 12 12 12)))
+    (is (not (is-expired? "2018-01-10T12:12:12-02:00" (date-time 2018 1 10 12 12 12)))))
+  (testing "other timezone and milliseconds"
+    (is (is-expired? "2018-01-11T12:12:12.000+02:00" (date-time 2018 1 11 12 12 12)))
+    (is (not (is-expired? "2018-01-12T12:12:12.000-02:00" (date-time 2018 1 12 12 12 12))))))

--- a/test/clostack/date_test.clj
+++ b/test/clostack/date_test.clj
@@ -1,5 +1,5 @@
 (ns clostack.date-test
-  (:require [clostack.date :refer [is-expired?]]
+  (:require [clostack.date :refer [is-expired? expires-args]]
             [clj-time.core :refer [date-time]]
             [clojure.test :refer :all]))
 
@@ -22,3 +22,11 @@
   (testing "other timezone and milliseconds"
     (is (is-expired? "2018-01-11T12:12:12.000+02:00" (date-time 2018 1 11 12 12 12)))
     (is (not (is-expired? "2018-01-12T12:12:12.000-02:00" (date-time 2018 1 12 12 12 12))))))
+
+(deftest signature-v3
+  (testing "expires and signatureVersion args"
+           (is (:expires (expires-args 0)))
+           (is (= (:signatureVersion (expires-args 0))
+                  "3")))
+  (testing "negative expiration time produces nothing"
+           (is (not (:expires (expires-args -1))))))

--- a/test/clostack/payload_test.clj
+++ b/test/clostack/payload_test.clj
@@ -1,5 +1,5 @@
 (ns clostack.payload-test
-  (:require [clostack.payload :refer [add-expires sign]]
+  (:require [clostack.payload :refer [sign]]
             [clojure.test :refer :all]))
 
 (def API_KEY "key")
@@ -13,11 +13,3 @@
             (sign {:a "a" :B "B"} API_SECRET)))
   (is (not= (sign {:a "a" :b [{:c 1 :d true}]} API_SECRET)
             (sign {:a "a" :b [{:c 1 :D true}]} API_SECRET))))
-
-(deftest signature-v3
-  (testing "signature v3")
-  (is (= (:signatureVersion (add-expires {} 0))
-         "3"))
-  (is (:expires (add-expires {} 0)))
-  (is (not (:expires (add-expires {} -1))))
-  )

--- a/test/clostack/payload_test.clj
+++ b/test/clostack/payload_test.clj
@@ -1,5 +1,5 @@
 (ns clostack.payload-test
-  (:require [clostack.payload :refer [sign]]
+  (:require [clostack.payload :refer [add-expires sign]]
             [clojure.test :refer :all]))
 
 (def API_KEY "key")
@@ -13,3 +13,11 @@
             (sign {:a "a" :B "B"} API_SECRET)))
   (is (not= (sign {:a "a" :b [{:c 1 :d true}]} API_SECRET)
             (sign {:a "a" :b [{:c 1 :D true}]} API_SECRET))))
+
+(deftest signature-v3
+  (testing "signature v3")
+  (is (= (:signatureVersion (add-expires {} 0))
+         "3"))
+  (is (:expires (add-expires {} 0)))
+  (is (not (:expires (add-expires {} -1))))
+  )


### PR DESCRIPTION
This correctly produces...

```clj
{:page 1,
 :pagesize 1,
 :command listZones,
 :apikey EXOc94bc655ff901b7218a5c3cd,
 :response json,
 :signatureVersion 3, :expires 2018-10-01T10:12:19.174Z}
```

**but**

- [x] CloudStack don't like Z https://github.com/apache/cloudstack/pull/2867

