### PR TITLE
signature: pre condition to avoid npe

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject exoscale/clostack "0.2.15"
+(defproject exoscale/clostack "0.2.16-SNAPSHOT"
   :description "clojure cloudstack client"
   :url "https://github.com/exoscale/clostack"
   :license {:name "MIT License"}

--- a/src/clostack/signature.clj
+++ b/src/clostack/signature.clj
@@ -11,9 +11,10 @@
   "Given a secret, compute the base64 encoded representation of a
    payload's Hmac-Sha1"
   [^String secret ^String input]
+  {:pre [(seq secret)]}
   (let [key  (SecretKeySpec. (.getBytes secret) "HmacSHA1")
         mac  (doto (Mac/getInstance "HmacSHA1") (.init key))]
-    (->> input
-         .getBytes
-         (.doFinal mac)
-         (.encodeToString (Base64/getEncoder)))))
+    (some->> input
+             .getBytes
+             (.doFinal mac)
+             (.encodeToString (Base64/getEncoder)))))

--- a/test/clostack/payload_test.clj
+++ b/test/clostack/payload_test.clj
@@ -6,10 +6,10 @@
 (def API_SECRET "secret")
 
 (deftest sign-case-sensitivity
-  (testing "sha1 signature case sensitivity")
-  (is (not= (sign {"a" "a" "b" "B"} API_SECRET)
-            (sign {"a" "a" "B" "B"} API_SECRET)))
-  (is (not= (sign {:a "a" :b "B"} API_SECRET)
-            (sign {:a "a" :B "B"} API_SECRET)))
-  (is (not= (sign {:a "a" :b [{:c 1 :d true}]} API_SECRET)
-            (sign {:a "a" :b [{:c 1 :D true}]} API_SECRET))))
+  (testing "sha1 signature case sensitivity"
+    (is (not= (sign {"a" "a" "b" "B"} API_SECRET)
+              (sign {"a" "a" "B" "B"} API_SECRET)))
+    (is (not= (sign {:a "a" :b "B"} API_SECRET)
+              (sign {:a "a" :B "B"} API_SECRET)))
+    (is (not= (sign {:a "a" :b [{:c 1 :d true}]} API_SECRET)
+              (sign {:a "a" :b [{:c 1 :D true}]} API_SECRET)))))

--- a/test/clostack/signature_test.clj
+++ b/test/clostack/signature_test.clj
@@ -1,0 +1,10 @@
+(ns clostack.signature-test
+  (:require [clostack.signature :refer [sha1-signature]]
+            [clojure.test :refer :all]))
+
+(deftest sha1-signature-nils
+  (testing "sha1 signature without a secret"
+    (is (thrown? AssertionError
+                 (sha1-signature nil "input"))))
+  (testing "sha1 signature without an input"
+    (is (nil? (sha1-signature "secret" nil)))))


### PR DESCRIPTION
Where the library is used, it's doing things to avoid the NPE. This clarifies the existence of that code there.

How do you see those as well as having assertions here and there (`*assert*`)