### PR TITLE
Cloak api-secret to defend against accidental leakage

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -3,4 +3,5 @@
  {org.clojure/clojure    {:mvn/version "1.10.1"}
   aleph                  {:mvn/version "0.4.6"}
   cheshire               {:mvn/version "5.9.0"}
-  clj-time               {:mvn/version "0.15.2"}}}
+  clj-time               {:mvn/version "0.15.2"}
+  exoscale/cloak         {:mvn/version "0.1.2"}}}

--- a/src/clostack/client.clj
+++ b/src/clostack/client.clj
@@ -16,7 +16,7 @@
      - :config a map of the following optional:
        - :endpoint HTTP endpoint for the API
        - :api-key
-       - :api-secret
+       - :api-secret (value may be \"cloaked\" by exoscale.cloak)
        - :request-method (:get or :post, default to :post)
        - :page-size number of entities to fetch per page (500 per default)
      - :opts: an opt map handed out to aleph's http client

--- a/src/clostack/config.clj
+++ b/src/clostack/config.clj
@@ -3,7 +3,8 @@
    to find configuration for the library. See the `init` function
    for a description of the logic."
   (:require [clojure.string :as s]
-            [clojure.edn    :as edn]))
+            [clojure.edn    :as edn]
+            [exoscale.cloak :as cloak]))
 
 (defn getenv
   "Fetch variable from environment or system properties"
@@ -57,9 +58,10 @@
   (let [path    (config-path)
         config  (keywordify (read-config path))
         profile (keyword (getenv :clostack.profile "default"))]
-    (keywordify
-     (or (environment-config)
-         (file-config profile config)
-         (throw (ex-info "Could not find configuration profile for clostack."
-                         {:config-path path
-                          :config config}))))))
+    (-> (keywordify
+         (or (environment-config)
+             (file-config profile config)
+             (throw (ex-info "Could not find configuration profile for clostack."
+                             {:config-path path
+                              :config config}))))
+        (update :api-secret cloak/mask))))

--- a/src/clostack/payload.clj
+++ b/src/clostack/payload.clj
@@ -5,7 +5,9 @@
             [clojure.string     :as s]
             [clostack.date      :refer [expires-args]]
             [clostack.signature :as sig]
-            [clostack.utils     :refer [url-encode quote-plus]]))
+            [clostack.utils     :refer [url-encode quote-plus]]
+            [exoscale.cloak     :as cloak]))
+
 
 (def default-expiration 600)
 
@@ -87,5 +89,5 @@
           args       (-> args
                          (assoc :apiKey api-key :response "json")
                          (merge exp-args))
-          signature  (sign args api-secret)]
+          signature  (sign args (cloak/unmask api-secret))]
       (assoc args :signature signature))))


### PR DESCRIPTION
We want to avoid having having the API secret hanging around in plain text. The risk is the clostack client might be logged and while it might be useful to have the key and endpoint in the logs, it is a security risk to include the api-secret.

After reading the secret from the environment or config as per usual, this PR arranges for it to be hidden by exoscale.cloak. This means that if the client by some using application, `"<< cloaked >>"` will be printed in place of the actual api-secret. The actual secret is only revealed at the point of signing the request.