### PR TITLE
clostack.client: safely parse response body

### DIFF
--- a/src/clostack/client.clj
+++ b/src/clostack/client.clj
@@ -67,10 +67,19 @@
        (some-> config :request-method name str/lower-case keyword)
        http-post))
 
+(defn safe-parse-json-body
+  [body]
+  (try
+    (-> body
+        bs/to-reader
+        (json/parse-stream true))
+    (catch Exception e
+      {:original-body body
+       :parser-exception-message (ex-message e)})))
+
 (defn parse-body
   [response]
-  (let [parse-json-body #(-> % bs/to-reader (json/parse-stream true))]
-    (update response :body parse-json-body)))
+  (update response :body safe-parse-json-body))
 
 (defn prepare-error-fn
   [f]

--- a/test/clostack/client_test.clj
+++ b/test/clostack/client_test.clj
@@ -1,0 +1,33 @@
+(ns clostack.client-test
+  (:require
+   [cheshire.core :as json]
+   [clojure.test :refer [deftest is testing]]
+   [clostack.client :as sut]))
+
+(deftest prepare-error-fn-test
+  (testing "exception from server with JSON response"
+    (let [json-payload "{\"message\":\"Sorry, we are broken\"}"
+          f (sut/prepare-error-fn identity)
+          ex (ex-info "This is an error from the server"
+                      {:status 400
+                       :headers []
+                       :body json-payload})
+          {:keys [status body headers exception]} (f ex)]
+      (is (= 400 status))
+      (is (= [] headers))
+      (is (= (json/parse-string json-payload true) body))
+      (is (= ex exception))))
+
+  (testing "exception from server with not a JSON response"
+    (let [not-json-payload "<html><body>we are deeply broken</body></html>"
+          f (sut/prepare-error-fn identity)
+          ex (ex-info "This is an error from the server"
+                      {:status 400
+                       :headers []
+                       :body not-json-payload})
+          {:keys [status body headers exception]} (f ex)]
+      (is (= 400 status))
+      (is (= [] headers))
+      (is (= not-json-payload (:original-body body)))
+      (is (not-empty (:parser-exception-message body)))
+      (is (= ex exception)))))


### PR DESCRIPTION
Always returns a hash-map body, with details in case of failure parsing the original body.
This will allow bubbling up server issues to the caller and fail with actionable information.